### PR TITLE
Defaults and const for custom types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "bitfield-struct"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitfield-struct"
-version = "0.4.4"
+version = "0.5.0"
 edition = "2021"
 authors = ["Lars Wrenger <lars@wrenger.net>"]
 description = "Procedural macro for bitfields."

--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ struct MyBitfield {
     /// sign extend for signed integers
     #[bits(13)]
     negative: i16,
-    /// supports any type, with `into`/`from` expressions (that are const eval)
+    /// supports any type, with `into_bits`/`from_bits` (const) functions,
+    /// if not configured otherwise with the `into`/`from` parameters of the bits attribute.
     ///
-    /// the field is initialized with 0 (passed into `from`) if not specified otherwise
-    #[bits(16, into = this as _, from = CustomEnum::from_bits(this))]
+    /// the field is initialized with 0 (passed into `from_bits`) if not specified otherwise
+    #[bits(16)]
     custom: CustomEnum,
     /// public field -> public accessor functions
     #[bits(12)]
@@ -119,7 +120,10 @@ enum CustomEnum {
     C = 2,
 }
 impl CustomEnum {
-    // This has to be const eval
+    // This has to be a const fn
+    const fn into_bits(self) -> u64 {
+        self as _
+    }
     const fn from_bits(value: u64) -> Self {
         match value {
             0 => Self::A,

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bitfield-struct = "0.4"
+bitfield-struct = "0.5"
 ```
 
 ## Basics
@@ -88,7 +88,7 @@ The example below shows how attributes are carried over and how signed integers,
 struct MyBitfield {
     /// defaults to 16 bits for u16
     int: u16,
-    /// interpreted as 1 bit flag, with custom default
+    /// interpreted as 1 bit flag, with a custom default value
     #[bits(default = true)]
     flag: bool,
     /// custom bit size
@@ -97,8 +97,10 @@ struct MyBitfield {
     /// sign extend for signed integers
     #[bits(13)]
     negative: i16,
-    /// supports any type, with default/to/from expressions (that are const eval)
-    #[bits(16, default = CustomEnum::A, into = this as _, from = CustomEnum::from_bits(this))]
+    /// supports any type, with `into`/`from` expressions (that are const eval)
+    ///
+    /// the field is initialized with 0 (passed into `from`) if not specified otherwise
+    #[bits(16, into = this as _, from = CustomEnum::from_bits(this))]
     custom: CustomEnum,
     /// public field -> public accessor functions
     #[bits(12)]

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ struct MyBitfield {
     pub public: usize,
     /// padding
     #[bits(5)]
-    _p: u8,
+    __: u8,
 }
 
 /// A custom enum

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -18,10 +18,11 @@ fn members() {
         /// sign extend for signed integers
         #[bits(13)]
         negative: i16,
-        /// supports any type, with `into`/`from` expressions (that are const eval)
+        /// supports any type, with `into_bits`/`from_bits` expressions (that are const eval),
+        /// if not configured otherwise with the `into`/`from` parameters of the bits attribute.
         ///
-        /// the field is initialized with 0 (passed into `from`) if not specified otherwise
-        #[bits(16, into = this as _, from = CustomEnum::from_bits(this))]
+        /// the field is initialized with 0 (passed into `from_bits`) if not specified otherwise
+        #[bits(16)]
         custom: CustomEnum,
         /// public field -> public accessor functions
         #[bits(12)]
@@ -40,6 +41,9 @@ fn members() {
         C = 2,
     }
     impl CustomEnum {
+        const fn into_bits(self) -> u64 {
+            self as _
+        }
         const fn from_bits(value: u64) -> Self {
             match value {
                 0 => Self::A,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -9,7 +9,7 @@ fn members() {
     struct MyBitfield {
         /// defaults to 16 bits for u16
         int: u16,
-        /// interpreted as 1 bit flag
+        /// interpreted as 1 bit flag, with a custom default value
         #[bits(default = true)]
         flag: bool,
         /// custom bit size
@@ -18,8 +18,10 @@ fn members() {
         /// sign extend for signed integers
         #[bits(13)]
         negative: i16,
-        /// supports any type, with default/to/from expressions (that are const eval)
-        #[bits(16, default = CustomEnum::A, into = this as _, from = CustomEnum::from_bits(this))]
+        /// supports any type, with `into`/`from` expressions (that are const eval)
+        ///
+        /// the field is initialized with 0 (passed into `from`) if not specified otherwise
+        #[bits(16, into = this as _, from = CustomEnum::from_bits(this))]
         custom: CustomEnum,
         /// public field -> public accessor functions
         #[bits(12)]
@@ -51,13 +53,15 @@ fn members() {
         .with_int(3 << 15)
         .with_tiny(1)
         .with_negative(-3)
-        .with_custom(CustomEnum::B)
         .with_public(2);
 
     println!("{val:?}");
 
     let raw: u64 = val.into();
     println!("{raw:b}");
+
+    assert_eq!(val.custom(), CustomEnum::A);
+    val.set_custom(CustomEnum::B);
 
     assert_eq!(val.int(), 3 << 15);
     assert_eq!(val.flag(), true); // from default


### PR DESCRIPTION
As discussed in #15, this PR adds support for default parameters. This is different from the standard library `Default` trait as the bitfields are usually also used in const-eval contexts.

The downside of const-ness is that custom types can no longer rely on the (non-const) `From`/`Into` traits and now require explicit conversion functions in the `bits` attribute.

Here is an example that uses defaults and custom types:

```rust
#[bitfield(u16)]
#[derive(PartialEq, Eq)]
struct MyBitfield {
    /// Interpreted as 1-bit flag, with custom default
    #[bits(default = true)]
    flag: bool,
    /// Supports any type, with default/to/from expressions (that are const eval)
    /// - into/from call #ty::into_bits/#ty::from_bits if nothing else is specified
    #[bits(13, default = CustomEnum::B, from = CustomEnum::my_from_bits)]
    custom: CustomEnum,
    // Padding with default
    #[bits(2, default = 0b10)]
    __: (),
}

/// A custom enum
#[derive(Debug, PartialEq, Eq)]
#[repr(u16)]
enum CustomEnum {
    A = 0,
    B = 1,
    C = 2,
}
impl CustomEnum {
    // This has to be const eval
    const fn into_bits(self) -> u16 {
        self as _
    }
    const fn my_from_bits(value: u16) -> Self {
        match value {
            0 => Self::A,
            1 => Self::B,
            _ => Self::C,
        }
    }
}

// Uses defaults
let val = MyBitfield::new();

assert_eq!(val.flag(), true);
assert_eq!(val.custom(), CustomEnum::B);
assert_eq!(val.0 >> 14, 0b10); // padding
```



