### PR TITLE
suppress clippy lint for clippy::bad_bit_mask on debug_assert emitted 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -469,7 +469,11 @@ impl ToTokens for Member {
                 #[doc = #location]
                 #vis const fn #with_ident(self, value: #ty) -> Self {
                     #[allow(unused_comparisons)]
-                    debug_assert!(if value >= 0 { value & !#mask == 0 } else { !value & !#mask == 0 }, "value out of bounds");
+                    #[allow(clippy::bad_bit_mask)]
+                    {
+                        debug_assert!(if value >= 0 { value & !#mask == 0 } else { !value & !#mask == 0 }, "value out of bounds");
+                    }
+
                     Self(self.0 & !(#mask << #offset) | (value as #base_ty & #mask) << #offset)
                 }
                 #doc
@@ -487,7 +491,11 @@ impl ToTokens for Member {
                 #vis fn #with_ident(self, value: #ty) -> Self {
                     let value: #base_ty = value.into();
                     #[allow(unused_comparisons)]
-                    debug_assert!(if value >= 0 { value & !#mask == 0 } else { !value & !#mask == 0 }, "value out of bounds");
+                    #[allow(clippy::bad_bit_mask)]
+                    {
+                        debug_assert!(if value >= 0 { value & !#mask == 0 } else { !value & !#mask == 0 }, "value out of bounds");
+                    }
+
                     Self(self.0 & !(#mask << #offset) | (value & #mask) << #offset)
                 }
                 #doc


### PR DESCRIPTION
After upgrading to the latest version we started seeing the `clippy::bad_bit_mask` on some of our usage like the following was firing this lint:

```rust
#[bitfield(u32)]
pub struct MyBitfield {
    pub foo: u8,
    pub bar: u8,
    _reserved: u16,
}
```

The debug assert gets expanded to the following:
```rust
debug_assert!(
  if value >= 0 {
    value & !0xff == 0
  } else {
    !value & !0xff == 0
  },
  "value out of bounds");
```

I'm not comfortable enough with the code to say if you want to special case generating the debug_assert or not, but it seemed pretty reasonable to me to suppress the lint since it's a debug_assert. 