### PR TITLE
Add `#[track_caller]` to `with_*` and `set_*` functions.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -568,6 +568,7 @@ impl ToTokens for Member {
 
             #doc
             #[doc = #location]
+            #[cfg_attr(debug_assertions, track_caller)]
             #vis const fn #with_ident(self, value: #ty) -> Self {
                 let value: #base_ty = {
                     let this = value;
@@ -585,6 +586,7 @@ impl ToTokens for Member {
             }
             #doc
             #[doc = #location]
+            #[cfg_attr(debug_assertions, track_caller)]
             #vis fn #set_ident(&mut self, value: #ty) {
                 *self = self.#with_ident(value);
             }


### PR DESCRIPTION
I hit one of the debug assertions in my project recently, but the panic message was unhelpful because it pointed at the generated code instead of my own code.

Ideally, the panic message would also include the value that's out of bounds, but the feature that lets us format panics in `const` contexts is unstable.