### PR TITLE
Issue #22 proposed fix.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -727,7 +727,7 @@ fn parse_field(attrs: &[syn::Attribute], ty: &syn::Type, ignore: bool) -> syn::R
             // Bounds check and remove leading ones from negative values
             ret.into = quote! {{
                 #[allow(unused_comparisons)]
-                debug_assert!(if this >= 0 { this & !#mask == 0 } else { !this & !#mask == 0 }, "value out of bounds");
+                debug_assert!(if this >= 0 { this | #mask == #mask } else { !(this | #mask) == 0 }, "value out of bounds");
                 (this & #mask) as _
             }};
         }


### PR DESCRIPTION
Avoid performing logical and on !mask as this will cause a clippy lint error if result is 0.

Reformulate boolean check to os logial or opereations instead.