### PR TITLE
Added from_bits and into_bits functions.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,12 @@ fn bitfield_inner(args: TokenStream, input: TokenStream) -> syn::Result<TokenStr
                 #( #defaults )*
                 this
             }
+            #vis const fn from_bits(bits: #ty) -> Self {
+                Self(bits)
+            }
+            #vis const fn into_bits(self) -> #ty {
+                self.0
+            }
 
             #( #members )*
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -364,3 +364,22 @@ fn msb_order() {
 
     assert_eq!(v.0, 0xe11e_00_f0);
 }
+
+#[test]
+fn nested() {
+    #[bitfield(u8)]
+    #[derive(PartialEq)]
+    struct Child {
+        contents: u8,
+    }
+    #[bitfield(u8)]
+    #[derive(PartialEq)]
+    struct Parent {
+        #[bits(8)]
+        child: Child,
+    }
+    let child = Child::new().with_contents(0xff);
+    let parent = Parent::new().with_child(child);
+    assert_eq!(child.into_bits(), 0xff);
+    assert_eq!(parent.into_bits(), 0xff);
+}


### PR DESCRIPTION
This PR modifies the `bitfield` attribute macro to automatically emit `from_bits` and `into_bits` functions for types on which it is applied. This makes nesting types a lot easier.