### PR TITLE
Add missing documentation for from_bits() and into_bits()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,9 +121,11 @@ fn bitfield_inner(args: TokenStream, input: TokenStream) -> syn::Result<TokenStr
 
     let conversion = if conversion {
         quote! {
+            /// Convert from bits.
             #vis const fn from_bits(bits: #ty) -> Self {
                 Self(bits)
             }
+            /// Convert into bits.
             #vis const fn into_bits(self) -> #ty {
                 self.0
             }


### PR DESCRIPTION
Fix warnings about missing documentation if `#![warn(missing_docs)]` is enabled.

For example:
```
warning: missing documentation for a method
   --> xxx/src/lib.rs:654:1
    |
654 | #[bitfield(u32)]
    | ^^^^^^^^^^^^^^^^ in this procedural macro expansion
    |
   ::: /home/xxx/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bitfield-struct-0.6.1/src/lib.rs:39:1
    |
39  | pub fn bitfield(args: pc::TokenStream, input: pc::TokenStream) -> pc::TokenStream {
    | --------------------------------------------------------------------------------- in this expansion of `#[bitfield]`
```