### PR TITLE
Add support for custom inner types

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -398,3 +398,30 @@ fn raw() {
     assert_eq!(raw.r#type(), 0xff);
     assert_eq!(raw.into_bits(), 0xff);
 }
+
+#[test]
+fn custom_inner() {
+    #[bitfield(u32, inner = CustomInner, from = CustomInner::from_inner, into = CustomInner::to_inner)]
+    #[derive(PartialEq, Eq)]
+    struct MyBitfield {
+        data: u32,
+    }
+
+    #[derive(PartialEq, Eq, Clone, Copy, Debug)]
+    #[repr(transparent)]
+    struct CustomInner(u32);
+
+    impl CustomInner {
+        const fn to_inner(self) -> u32 {
+            self.0
+        }
+
+        const fn from_inner(inner: u32) -> Self {
+            Self(inner)
+        }
+    }
+
+    let my_bitfield = MyBitfield::new();
+    assert_eq!(my_bitfield, MyBitfield::from_bits(CustomInner(0)));
+    assert_eq!(my_bitfield.into_bits(), CustomInner(0));
+}


### PR DESCRIPTION
This PR adds support for custom storage types of bitfields.

I am not sure if I put everything where you would want it to be, @wrenger
I have not added documentation for this yet, as I first wanted to get your opinion on the code.

Closes https://github.com/wrenger/bitfield-struct-rs/issues/38