### PR TITLE
Make equality assertions consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,11 +278,11 @@ let my_byte_lsb = MyLsbByte::new()
     .with_level(2)
     .with_present(true);
 
-//                         .- present
-//                         | .- level
-//                         | |  .- system
-//                         | |  | .- kind
-assert!(my_byte_lsb.0 == 0b1_10_0_1010);
+//                          .- present
+//                          | .- level
+//                          | |  .- system
+//                          | |  | .- kind
+assert_eq!(my_byte_lsb.0, 0b1_10_0_1010);
 ```
 
 The macro generates the reverse order when Msb (most significant bit) is specified:
@@ -307,11 +307,11 @@ let my_byte_msb = MyMsbByte::new()
     .with_level(2)
     .with_present(true);
 
-//                         .- kind
-//                         |    .- system
-//                         |    | .- level
-//                         |    | |  .- present
-assert!(my_byte_msb.0 == 0b1010_0_10_1);
+//                          .- kind
+//                          |    .- system
+//                          |    | .- level
+//                          |    | |  .- present
+assert_eq!(my_byte_msb.0, 0b1010_0_10_1);
 ```
 
 ## `fmt::Debug` and `Default`

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -112,7 +112,7 @@ fn attrs() {
 
     let full = Full::new().with_data(u64::MAX);
     assert_eq!(full.data(), u64::MAX);
-    assert!(full == Full::new().with_data(u64::MAX));
+    assert_eq!(full, Full::new().with_data(u64::MAX));
 }
 
 #[test]


### PR DESCRIPTION
Everywhere else, `assert_eq!` is already used for equality assertions.