### PR TITLE
add optional automatic defmt implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,10 +6,49 @@ version = 3
 name = "bitfield-struct"
 version = "0.7.0"
 dependencies = [
+ "defmt",
  "endian-num",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.65",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "defmt"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a99dd22262668b887121d4672af5a64b238f026099f1a2a1b322066c9ecfe9e0"
+dependencies = [
+ "bitflags",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9f309eff1f79b3ebdf252954d90ae440599c26c2c553fe87a2d17195f2dcb"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4a5fefe330e8d7f31b16a318f9ce81000d8e35e69b93eae154d16d2278f70f"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -17,6 +56,30 @@ name = "endian-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad847bb2094f110bbdd6fa564894ca4556fd978958e93985420d680d3cb6d14"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -38,6 +101,16 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
@@ -48,7 +121,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,5 @@ syn = { version = "2.0", features = ["full"] }
 proc-macro2 = "1.0"
 
 [dev-dependencies]
+defmt = "0.3"
 endian-num = { version = "0.1", features = ["linux-types"] }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ As this library provides a procedural macro, it has no runtime dependencies and 
 - Rust-analyzer friendly (carries over documentation to accessor functions)
 - Exports field offsets and sizes as constants (useful for const asserts)
 - Generation of `fmt::Debug` and `Default`
+- Optional generation of `defmt::Format`
 
 ## Usage
 
@@ -395,3 +396,16 @@ impl Default for CustomDebug {
 let val = CustomDebug::default();
 println!("{val:?}")
 ```
+
+## `defmt::Format`
+
+This macro can automatically implement a `defmt::Format` that mirrors the default `fmt::Debug` implementation by passing the extra `defmt` argument. This implementation requires the defmt crate to be available as `defmt`, and has the same rules and caveats as `#[derive(defmt::Format)]`.
+
+```rust
+use bitfield_struct::bitfield;
+
+#[bitfield(u64, defmt = true)]
+struct DefmtExample {
+    data: u64
+}
+````

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -878,11 +878,21 @@ mod test {
     fn parse_args() {
         let args = quote!(u64);
         let params = syn::parse2::<Params>(args).unwrap();
-        assert!(params.bits == u64::BITS as usize && params.debug == true);
+        assert_eq!(params.bits, u64::BITS as usize);
+        assert_eq!(params.debug, true);
+        assert_eq!(params.defmt, false);
 
         let args = quote!(u32, debug = false);
         let params = syn::parse2::<Params>(args).unwrap();
-        assert!(params.bits == u32::BITS as usize && params.debug == false);
+        assert_eq!(params.bits, u32::BITS as usize);
+        assert_eq!(params.debug, false);
+        assert_eq!(params.defmt, false);
+
+        let args = quote!(u32, defmt = true);
+        let params = syn::parse2::<Params>(args).unwrap();
+        assert_eq!(params.bits, u32::BITS as usize);
+        assert_eq!(params.debug, true);
+        assert_eq!(params.defmt, true);
 
         let args = quote!(u32, order = Msb);
         let params = syn::parse2::<Params>(args).unwrap();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -134,7 +134,6 @@ fn debug() {
 }
 
 // a dummy defmt logger and timestamp implementation, for testing
-#[cfg(test)]
 mod defmt_logger {
     #[defmt::global_logger]
     struct Logger;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -133,6 +133,107 @@ fn debug() {
     println!("{full:?}");
 }
 
+// a dummy defmt logger and timestamp implementation, for testing
+#[cfg(test)]
+mod defmt_logger {
+    #[defmt::global_logger]
+    struct Logger;
+
+    unsafe impl defmt::Logger for Logger {
+        fn acquire() {}
+        unsafe fn flush() {}
+        unsafe fn release() {}
+        unsafe fn write(_bytes: &[u8]) {}
+    }
+
+    defmt::timestamp!("");
+}
+
+#[test]
+fn defmt() {
+    #[bitfield(u64, defmt = true)]
+    struct Full {
+        data: u64,
+    }
+
+    let full = Full::new().with_data(123);
+    defmt::println!("{:?}", full);
+}
+
+#[test]
+fn defmt_primitives() {
+    #[bitfield(u128, defmt = true)]
+    struct Unsigned {
+        a: bool,
+        #[bits(7)]
+        __: u8,
+        b: u8,
+        c: u16,
+        d: u32,
+        e: u64,
+    }
+
+    defmt::println!("{}", Unsigned::new());
+
+    #[bitfield(u128, defmt = true)]
+    struct FullUnsigned {
+        data: u128,
+    }
+
+    defmt::println!("{}", FullUnsigned::new());
+
+    #[bitfield(u128, defmt = true)]
+    struct Signed {
+        a: bool,
+        #[bits(7)]
+        __: u8,
+        b: i8,
+        c: i16,
+        d: i32,
+        e: i64,
+    }
+
+    defmt::println!("{}", Signed::new());
+
+    #[bitfield(u128, defmt = true)]
+    struct FullSigned {
+        data: i128,
+    }
+
+    defmt::println!("{}", FullSigned::new());
+
+    #[bitfield(u128, defmt = true)]
+    struct Size {
+        #[bits(64)]
+        a: usize,
+        #[bits(64)]
+        b: usize,
+    }
+
+    defmt::println!("{}", Size::new());
+
+    const fn f32_from_bits(_bits: u32) -> f32 {
+        // just for testing
+        0.0
+    }
+
+    const fn f64_from_bits(_bits: u64) -> f64 {
+        // just for testing
+        0.0
+    }
+
+    #[bitfield(u128, defmt = true)]
+    struct Float {
+        __: u32,
+        #[bits(32, from = f32_from_bits, access = RO)]
+        a: f32,
+        #[bits(64, from = f64_from_bits, access = RO)]
+        b: f64,
+    }
+
+    defmt::println!("{}", Float::new());
+}
+
 #[test]
 fn positive() {
     #[bitfield(u32)]


### PR DESCRIPTION
This PR adds a `defmt` option to the `bitfield` macro, which adds code to implement `defmt::Format`. It also adds info to the README and a few appropriate tests.

Some implementation notes you might want to know:

 * Defmt has [built-in support for bitfields][defmt-bitfield] which leads to a very compact representation, however this method always outputs plain integers for the fields. I chose *not* to use this, and instead format each field separately, in order to take advantage of the `defmt::Format` implementations on any custom types. I feel like this better matches the default `fmt::Debug` implementation. I considered doing both, and making it configurable, but that seemed like too big a change.

  [defmt-bitfield]: https://defmt.ferrous-systems.com/ser-bitfield

 * This macro assumes any type named `u8` is the primitive `u8`, etc. This is also what the official defmt derive macro does, to more efficiently encode these values. It looks like the `bitfield` macro already makes this assumption when figuring out default bit widths, so probably not a big deal.

 * The generated code uses `defmt` to refer to defmt, and not `::defmt`. This is what the defmt crate itself does in its own macros, for [some pretty subtle reasons][defmt-name]. I've added a big comment in the code about this, to hopefully prevent somebody from 'fixing' it.

  [defmt-name]: https://github.com/knurling-rs/defmt/pull/835

Please let me know if you would like any changes, or have any questions!