### PR TITLE
Fix padding fields default value being ignored when using Msb

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,6 +536,10 @@ impl ToTokens for Member {
     }
 }
 
+impl ToTokens for Order {
+    fn to_tokens(&self, _tokens: &mut TokenStream) {}
+}
+
 /// Distinguish between different types for code generation.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 enum TypeClass {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,6 @@ struct Member {
     repr_into: Option<syn::Path>,
     repr_from: Option<syn::Path>,
     default: TokenStream,
-    order: Order,
     inner: Option<MemberInner>,
 }
 
@@ -385,7 +384,6 @@ impl Member {
                 repr_into,
                 repr_from,
                 default,
-                order,
                 inner: Some(MemberInner {
                     ident,
                     ty,
@@ -407,7 +405,6 @@ impl Member {
                 repr_into,
                 repr_from,
                 default,
-                order,
                 inner: None,
             })
         }
@@ -430,7 +427,6 @@ impl Member {
         let repr_into = &self.repr_into;
         let repr_from = &self.repr_from;
         let bits = self.bits as u32;
-        let order = self.order;
 
         quote! {
             let mask = #base_ty::MAX >> (#base_ty::BITS - #bits);
@@ -448,7 +444,6 @@ impl ToTokens for Member {
             repr_into,
             repr_from,
             default: _,
-            order: _,
             inner:
                 Some(MemberInner {
                     ident,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,9 +430,22 @@ impl Member {
         let repr_into = &self.repr_into;
         let repr_from = &self.repr_from;
         let bits = self.bits as u32;
-        quote!{
-            let mask = #base_ty::MAX >> (#base_ty::BITS - #bits);
-            this.0 = #repr_from(#repr_into(this.0) | (((#default as #base_ty) & mask) << #offset));
+        let order = self.order;
+
+        match order {
+            Order::Lsb => {
+                quote! {
+                    let mask = #base_ty::MAX >> (#base_ty::BITS - #bits);
+                    this.0 = #repr_from(#repr_into(this.0) | (((#default as #base_ty) & mask) << #offset));
+                }
+            }
+            Order::Msb => {
+                quote! {
+                    let mask = #base_ty::MAX >> (#base_ty::BITS - #bits);
+                    let offset = (#base_ty::BITS as #base_ty - #bits as #base_ty) - #offset as #base_ty;
+                    this.0 = #repr_from(#repr_into(this.0) | (((#default as #base_ty) & mask) << offset));
+                }
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -553,10 +553,6 @@ impl ToTokens for Member {
     }
 }
 
-impl ToTokens for Order {
-    fn to_tokens(&self, _tokens: &mut TokenStream) {}
-}
-
 /// Distinguish between different types for code generation.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 enum TypeClass {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,6 +295,7 @@ struct Member {
     repr_into: Option<syn::Path>,
     repr_from: Option<syn::Path>,
     default: TokenStream,
+    order: Order,
     inner: Option<MemberInner>,
 }
 
@@ -384,6 +385,7 @@ impl Member {
                 repr_into,
                 repr_from,
                 default,
+                order,
                 inner: Some(MemberInner {
                     ident,
                     ty,
@@ -405,6 +407,7 @@ impl Member {
                 repr_into,
                 repr_from,
                 default,
+                order,
                 inner: None,
             })
         }
@@ -443,6 +446,7 @@ impl ToTokens for Member {
             repr_into,
             repr_from,
             default: _,
+            order: _,
             inner:
                 Some(MemberInner {
                     ident,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -565,3 +565,31 @@ fn default_without_setter() {
         reserved: bool
     }
 }
+
+#[test]
+fn default_msb_padding_default_value() {
+    #[bitfield(u8, order = Msb)]
+    struct MyMsbByte {
+        #[bits(4, default = 0b1111)]
+        __padding: usize,
+        #[bits(4, default = 0b1010)]
+        kind: usize,
+    }
+    let my_byte_msb = MyMsbByte::new();
+    let val: u8 = my_byte_msb.into();
+    assert_eq!(val, 0b1111_1010);
+}
+
+#[test]
+fn default_lsb_padding_default_value() {
+    #[bitfield(u8, order = Lsb)]
+    struct MyMsbByte {
+        #[bits(4, default = 0b1111)]
+        __padding: usize,
+        #[bits(4, default = 0b1010)]
+        kind: usize,
+    }
+    let my_byte_msb = MyMsbByte::new();
+    let val: u8 = my_byte_msb.into();
+    assert_eq!(val, 0b1010_1111);
+}


### PR DESCRIPTION
This PR fixes #56 which describes using a padding field with Msb, its default value won't get set. This change will ensure that the default value for padding fields will be set when using Msb order.

This PR works by passing the order enum to the Members struct then for padding fields without a setter, it checks the order then calculates the right shift offset.