### PR TITLE
Create from bits function to respect padding and default values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ fn s_err(span: proc_macro2::Span, msg: impl fmt::Display) -> syn::Error {
 /// - `defmt` to enable the `defmt::Format` trait generation.
 /// - `default` to disable the `Default` trait generation
 /// - `order` to specify the bit order (Lsb, Msb)
-/// - `conversion` to disable the generation of `into_bits` and `from_bits`
+/// - `conversion` to disable the generation of `into_bits`, `from_bits`, and `from_bits_with_defaults`
 ///
 /// > For `new`, `debug`, `defmt` or `default`, you can either use booleans
 /// > (`#[bitfield(u8, debug = false)]`) or cfg attributes

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -565,3 +565,20 @@ fn default_without_setter() {
         reserved: bool
     }
 }
+
+#[test]
+fn from_bits_with_defaults() {
+    #[bitfield(u32)]
+    struct MyBitfield {
+        #[bits(16, default = 0)]
+        _reserved: u32,
+        #[bits(16, default = 0xFFFF)]
+        data: u32,
+    }
+    let from_bits_val = MyBitfield::from_bits(0xffff_ffff);
+    let from_bits_raw: u32 = from_bits_val.into();
+    assert_eq!(from_bits_raw, 0xffff_ffff);
+    let from_bits_with_defaults_val = MyBitfield::from_bits_with_defaults(0xffff_ffff);
+    let from_bits_raw: u32 = from_bits_with_defaults_val.into();
+    assert_eq!(from_bits_raw, 0xffff_0000);
+}


### PR DESCRIPTION
As described in #55, this PR adds a new function that creates a bitfield struct from bits while respecting padding and default values.